### PR TITLE
@ #6 | should update to use teracy-dev v0.6.0-a5: use the snapshot version for now

### DIFF
--- a/config_default.yaml
+++ b/config_default.yaml
@@ -10,7 +10,7 @@ teracy-dev:
   # teracy-dev location specification
   location:
     git: https://github.com/teracyhq/dev.git
-    branch: v0.6.0-a4
+    branch: develop
     sync: true
 
   # teracy-dev-entry auto update


### PR DESCRIPTION
connect #6