### PR TITLE
the latest ansible version should not be required to run k8s ansible provision in guest mode

### DIFF
--- a/config_default.yaml
+++ b/config_default.yaml
@@ -83,7 +83,6 @@ nodes:
 
 teracy-dev-k8s:
   ansible:
-    version: latest
     host_vars:
       ingress_nginx_enabled: "True"
       helm_enabled: "True"


### PR DESCRIPTION
connect #14 
should not have `version` config, it will reinstall ansible! 